### PR TITLE
Update CRASH-UPLOAD.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/CRASH-UPLOAD.yml
+++ b/.github/ISSUE_TEMPLATE/CRASH-UPLOAD.yml
@@ -39,7 +39,9 @@ body:
   - type: markdown
     id: log-files
     attributes:
-      value: 如果日志太长无法提交，请将日志文件拖放到这里 (不要在这里粘贴日志)
+      value: |
+        ### 日志文件
+        如果日志太长无法提交，请将日志文件拖放到这里 (不要在这里粘贴日志)
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/CRASH-UPLOAD.yml
+++ b/.github/ISSUE_TEMPLATE/CRASH-UPLOAD.yml
@@ -36,6 +36,14 @@ body:
       render: bash
     validations:
       required: true
+  - type: markdown
+    id: log-files
+    attributes:
+      label: "崩溃日志文件"
+      description: 如果日志太长无法提交，请将日志文件拖放到这里 (不要在这里粘贴日志)
+      placeholder: 日志文件...
+    validations:
+      required: false
   - type: dropdown
     id: os
     attributes:

--- a/.github/ISSUE_TEMPLATE/CRASH-UPLOAD.yml
+++ b/.github/ISSUE_TEMPLATE/CRASH-UPLOAD.yml
@@ -39,9 +39,7 @@ body:
   - type: markdown
     id: log-files
     attributes:
-      label: "崩溃日志文件"
-      description: 如果日志太长无法提交，请将日志文件拖放到这里 (不要在这里粘贴日志)
-      placeholder: 日志文件...
+      value: 如果日志太长无法提交，请将日志文件拖放到这里 (不要在这里粘贴日志)
     validations:
       required: false
   - type: dropdown


### PR DESCRIPTION
当日志很长时，用户无法粘贴到textarea或者无法提交超出长度的issue, 所以加了个markdown格子让用户可以直接拖拽上传文件